### PR TITLE
chore:opt dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN make build && chmod +x ./build/${BINARY}
 
 FROM debian:bullseye-slim
 
+ARG BINARY=micro-gateway-operator
+
 RUN mkdir -p /app/logs
 COPY --from=builder /app/build/${BINARY} /app/${BINARY}
 RUN chmod 755 /app/${BINARY}


### PR DESCRIPTION
## 优化dockerfile 
- 分阶段编译，各阶段ARG参数需要各自定义,没有办法复用，最终通过docker build  --build-arg 来统一覆盖